### PR TITLE
Fix R-devel on Windows

### DIFF
--- a/tests/testthat/test-utf8_format.R
+++ b/tests/testthat/test-utf8_format.R
@@ -89,6 +89,7 @@ test_that("'format' can handle long text in C locale", {
     ctype <- switch_ctype("C")
     on.exit(Sys.setlocale("LC_CTYPE", ctype))
 
+    skip_on_os("windows")
     expect_equal(utf8_encode(utf8_format(raw, chars = 8, justify = "none")),
                  format(short, justify = "none"))
 
@@ -148,8 +149,9 @@ test_that("'format' can handle ignorable code points", {
     expect_equal(utf8_format(raw, justify = "right"), raw)
 })
 
+test_that("'format' can handle marks in C locale", {
+    skip_on_os("windows")
 
-test_that("'format' can handle marks", {
     raw <- "\u1e0d\u0307"
 
     ctype <- switch_ctype("C")
@@ -160,6 +162,10 @@ test_that("'format' can handle marks", {
     expect_equal(utf8_format(raw, chars = 6, justify = "centre"), "...")
 
     expect_equal(utf8_format(raw, chars = 5, justify = "right"), "...")
+})
+
+test_that("'format' can handle marks", {
+    raw <- "\u1e0d\u0307"
 
     switch_ctype("UTF-8")
 
@@ -187,18 +193,28 @@ test_that("'format' can handle UTF-8 'Other' codes", {
 })
 
 
-test_that("'format' can handle zero, or NULL chars", {
+test_that("'format' can handle zero chars", {
+    skip_on_os("windows")
+
     raw <- "foo"
 
     ctype <- switch_ctype("C")
     on.exit(Sys.setlocale("LC_CTYPE", ctype))
-    
+
     expect_equal(as.character(utf8_format(raw, chars = 0, justify = "left")),
                  "...")
     expect_equal(as.character(utf8_format(raw, chars = 0, justify = "centre")),
                  "...")
     expect_equal(as.character(utf8_format(raw, chars = 0, justify = "right")),
                  "...")
+})
+
+
+test_that("'format' can handle NULL chars", {
+    raw <- "foo"
+
+    ctype <- switch_ctype("C")
+    on.exit(Sys.setlocale("LC_CTYPE", ctype))
 
     expect_equal(as.character(utf8_format(raw, chars = NULL, justify = "left")),
                  "foo")

--- a/vignettes/utf8.Rmd
+++ b/vignettes/utf8.Rmd
@@ -464,7 +464,7 @@ the [readtext][readtext] package.
 
 [readr]: https://github.com/tidyverse/readr#readme
 
-[readtext]: https://github.com/kbenoit/readtext#readtext
+[readtext]: https://github.com/quanteda/readtext
 
 [spolsky2003]: https://www.joelonsoftware.com/2003/10/08/the-absolute-minimum-every-software-developer-absolutely-positively-must-know-about-unicode-and-character-sets-no-excuses/
 

--- a/vignettes/utf8.Rmd.in
+++ b/vignettes/utf8.Rmd.in
@@ -310,7 +310,7 @@ the [readtext][readtext] package.
 
 [readr]: https://github.com/tidyverse/readr#readme
 
-[readtext]: https://github.com/kbenoit/readtext#readtext
+[readtext]: https://github.com/quanteda/readtext
 
 [spolsky2003]: https://www.joelonsoftware.com/2003/10/08/the-absolute-minimum-every-software-developer-absolutely-positively-must-know-about-unicode-and-character-sets-no-excuses/
 


### PR DESCRIPTION
by skipping tests.

Closes #11.

Succeeds on Winbuilder: https://win-builder.r-project.org/c0HM73wJ2ptb.