### PR TITLE
Include session information

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -22,10 +22,10 @@ Depends:
     R (>= 2.10)
 Suggests:
     cli,
-    covr,
     knitr,
     rlang,
     rmarkdown,
+    sessioninfo,
     testthat (>= 3.0.0),
     withr
 VignetteBuilder: 

--- a/README.Rmd
+++ b/README.Rmd
@@ -145,3 +145,10 @@ and if you choose to contribute, you must adhere to its terms.
 [emoji-print]: https://twitter.com/ptrckprry/status/887732831161425920 "MacOS Emoji Printing"
 [issues]: https://github.com/patperry/r-utf8/issues "Issues"
 [windows-enc2utf8]: https://twitter.com/ptrckprry/status/901494853758054401 "Windows enc2utf8 Bug"
+
+<!-- Session information -->
+<!-- ------- -->
+
+<!-- ```{r} -->
+<!-- sessioninfo::session_info(include_base = TRUE) -->
+<!-- ``` -->

--- a/vignettes/utf8.Rmd
+++ b/vignettes/utf8.Rmd
@@ -475,3 +475,11 @@ the [readtext][readtext] package.
 [utf8]: https://en.wikipedia.org/wiki/UTF-8
 
 [windows1252]: https://en.wikipedia.org/wiki/Windows-1252
+
+Session information
+-------
+
+```{r}
+sessioninfo::session_info(include_base = TRUE)
+```
+


### PR DESCRIPTION
At various point, the documentation refers to the current version of R; for example:

https://github.com/patperry/r-utf8/blob/15e56f01f3b1315d9fd6545aaeee7bdb7fc7d8a9/vignettes/utf8.Rmd#L294-L296

But, as a reader, it's not clear which R version you are referring to.

I think it'd be good to include session information both in README and vignette to avoid such confusion.