### PR TITLE
chore: Add direct include for snprintf

### DIFF
--- a/src/bytes.c
+++ b/src/bytes.c
@@ -17,6 +17,7 @@
 #include <assert.h>
 #include <ctype.h>
 #include <limits.h>
+#include <stdio.h>  // snprintf
 #include "rutf8.h"
 
 static int byte_width(uint8_t byte, int flags);


### PR DESCRIPTION
Flagged by `clang-tidy`: https://clang.llvm.org/extra/clang-tidy/checks/misc/include-cleaner.html