### PR TITLE
fledge: CRAN pre-release v1.2.4.9900

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -25,3 +25,4 @@
 ^compile_commands\.json$
 ^src/\.editorconfig$
 ^revdep$
+^index\.md$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: utf8
 Title: Unicode Text Processing
-Version: 1.2.4.9003
+Version: 1.2.4.9900
 Authors@R: 
     c(person(given = c("Patrick", "O."),
              family = "Perry",

--- a/NEWS.md
+++ b/NEWS.md
@@ -8,129 +8,23 @@
 
 ## Chore
 
-- Add ellipsis before optional args (#74).
-
-- Show NEWS on CRAN page (#42, #71).
-
-- Auto-update from GitHub Actions.
-
-  Run: https://github.com/patperry/r-utf8/actions/runs/14756861029
-
-- Match indent style.
-
-- Use roxygen2 with Markdown.
-
 - Replace `[v]sprintf()` with `[v]snprintf()` (#67).
 
-- Add direct include for snprintf (@MichaelChirico, #43).
+- Add direct include for `snprintf()` (@MichaelChirico, #43).
 
-  Run: https://github.com/patperry/r-utf8/actions/runs/14636196819
-
-  Run: https://github.com/patperry/r-utf8/actions/runs/10425486174
-
-  Run: https://github.com/patperry/r-utf8/actions/runs/10200110873
-
-  Run: https://github.com/patperry/r-utf8/actions/runs/9727975031
-
-  Run: https://github.com/patperry/r-utf8/actions/runs/9691616880
-
-## Continuous integration
-
-- Build-ignore.
-
-- Permissions, better tests for missing suggests, lints (#66).
-
-- Only fail covr builds if token is given (#65).
-
-- Always use `_R_CHECK_FORCE_SUGGESTS_=false` (#64).
-
-- Correct installation of xml2 (#63).
-
-- Explain (#62).
-
-- Add xml2 for covr, print testthat results (#61).
-
-- Fix (#60).
-
-- Sync (#59).
-
-- Avoid failure in fledge workflow if no changes (#58).
-
-- Fetch tags for fledge workflow to avoid unnecessary NEWS entries (#57).
-
-- Use larger retry count for lock-threads workflow (#56).
-
-- Ignore errors when removing pkg-config on macOS (#55).
-
-- Explicit permissions (#54).
-
-- Use styler from main branch (#53).
-
-- Need to install R on Ubuntu 24.04 (#52).
-
-- Use Ubuntu 24.04 and styler PR (#50).
-
-- Correctly detect branch protection (#49).
-
-- Use stable pak (#48).
-
-- Trigger run (#47).
-
-  - ci: Trigger run
-
-  - ci: Latest changes
-
-- Use pkgdown branch (#46).
-
-  - ci: Use pkgdown branch
-
-  - ci: Updates from duckdb
-
-- Install via R CMD INSTALL ., not pak (#44).
-
-  - ci: Install via R CMD INSTALL ., not pak
-
-  - ci: Bump version of upload-artifact action
-
-- Install local package for pkgdown builds.
-
-- Improve support for protected branches with fledge.
-
-- Improve support for protected branches, without fledge.
-
-- Sync with latest developments.
-
-- Use v2 instead of master.
-
-- Inline action.
-
-- Use dev roxygen2 and decor.
-
-- Fix on Windows, tweak lock workflow.
-
-- Avoid checking bashisms on Windows.
-
-- Better commit message.
-
-- Bump versions, better default, consume custom matrix.
-
-- Recent updates.
+- Add ellipsis before optional args (#74).
 
 ## Documentation
 
-- Formatting.
+- Show NEWS on CRAN page (#42, #71).
 
-- Reference index.
+- Add pkgdown reference index.
 
-- Use roxygen2 (#68, #69).
+- Use roxygen2 (#68, #69) with Markdown.
 
 ## Performance
 
 - Check interrupt every 1024 calls, avoids a division in tight loops.
-
-## Uncategorized
-
-- Internal changes only.
 
 
 # utf8 1.2.4 (2023-10-16)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,26 +1,14 @@
 <!-- NEWS.md is maintained by https://fledge.cynkra.com, contributors should not edit this file -->
 
-# utf8 1.2.4.9003 (2025-05-01)
-
-## Chore
-
-- Add ellipsis before optional args (#74).
-
-
-# utf8 1.2.4.9002 (2025-05-01)
-
-## Documentation
-
-- Formatting.
-
-
-# utf8 1.2.4.9001 (2025-04-30)
+# utf8 1.2.4.9900 (2025-05-01)
 
 ## Features
 
 - Strict argument checking for `utf8_format()` and `utf8_print()`, no extra arguments allowed.
 
 ## Chore
+
+- Add ellipsis before optional args (#74).
 
 - Show NEWS on CRAN page (#42, #71).
 
@@ -32,45 +20,23 @@
 
 - Use roxygen2 with Markdown.
 
-## Continuous integration
-
-- Build-ignore.
-
-- Build-ignore.
-
-## Documentation
-
-- Reference index.
-
-## Performance
-
-- Check interrupt every 1024 calls, avoids a division in tight loops.
-
-
-# utf8 1.2.4.9000 (2025-04-30)
-
-## Chore
-
 - Replace `[v]sprintf()` with `[v]snprintf()` (#67).
 
 - Add direct include for snprintf (@MichaelChirico, #43).
 
-## Documentation
-
-- Use roxygen2 (#68, #69).
-
-
-# utf8 1.2.3.9022 (2025-04-30)
-
-## Chore
-
-- Add direct include for snprintf (@MichaelChirico, #43).
-
-- Auto-update from GitHub Actions.
-
   Run: https://github.com/patperry/r-utf8/actions/runs/14636196819
 
+  Run: https://github.com/patperry/r-utf8/actions/runs/10425486174
+
+  Run: https://github.com/patperry/r-utf8/actions/runs/10200110873
+
+  Run: https://github.com/patperry/r-utf8/actions/runs/9727975031
+
+  Run: https://github.com/patperry/r-utf8/actions/runs/9691616880
+
 ## Continuous integration
+
+- Build-ignore.
 
 - Permissions, better tests for missing suggests, lints (#66).
 
@@ -88,160 +54,81 @@
 
 - Sync (#59).
 
-
-# utf8 1.2.3.9021 (2024-12-09)
-
-## Continuous integration
-
 - Avoid failure in fledge workflow if no changes (#58).
-
-
-# utf8 1.2.3.9020 (2024-12-08)
-
-## Continuous integration
 
 - Fetch tags for fledge workflow to avoid unnecessary NEWS entries (#57).
 
-
-# utf8 1.2.3.9019 (2024-12-07)
-
-## Continuous integration
-
 - Use larger retry count for lock-threads workflow (#56).
-
-
-# utf8 1.2.3.9018 (2024-11-28)
-
-## Continuous integration
 
 - Ignore errors when removing pkg-config on macOS (#55).
 
-
-# utf8 1.2.3.9017 (2024-11-27)
-
-## Continuous integration
-
 - Explicit permissions (#54).
 
-
-# utf8 1.2.3.9016 (2024-11-26)
-
-## Continuous integration
-
 - Use styler from main branch (#53).
-
-
-# utf8 1.2.3.9015 (2024-11-25)
-
-## Continuous integration
 
 - Need to install R on Ubuntu 24.04 (#52).
 
 - Use Ubuntu 24.04 and styler PR (#50).
 
+- Correctly detect branch protection (#49).
 
-# utf8 1.2.3.9014 (2024-11-22)
+- Use stable pak (#48).
 
-## Continuous integration
+- Trigger run (#47).
 
-  - Correctly detect branch protection (#49).
+  - ci: Trigger run
 
+  - ci: Latest changes
 
-# utf8 1.2.3.9013 (2024-11-18)
+- Use pkgdown branch (#46).
 
-## Continuous integration
+  - ci: Use pkgdown branch
 
-  - Use stable pak (#48).
+  - ci: Updates from duckdb
 
+- Install via R CMD INSTALL ., not pak (#44).
 
-# utf8 1.2.3.9012 (2024-11-11)
+  - ci: Install via R CMD INSTALL ., not pak
 
-## Continuous integration
+  - ci: Bump version of upload-artifact action
 
-  - Trigger run (#47).
-    
-      - ci: Trigger run
-    
-      - ci: Latest changes
+- Install local package for pkgdown builds.
 
+- Improve support for protected branches with fledge.
 
-# utf8 1.2.3.9011 (2024-10-28)
+- Improve support for protected branches, without fledge.
 
-## Continuous integration
+- Sync with latest developments.
 
-  - Use pkgdown branch (#46).
-    
-      - ci: Use pkgdown branch
-    
-      - ci: Updates from duckdb
-    
-      - ci: Trigger run
+- Use v2 instead of master.
 
+- Inline action.
 
-# utf8 1.2.3.9010 (2024-09-15)
+- Use dev roxygen2 and decor.
 
-## Continuous integration
+- Fix on Windows, tweak lock workflow.
 
-  - Install via R CMD INSTALL ., not pak (#44).
-    
-      - ci: Install via R CMD INSTALL ., not pak
-    
-      - ci: Bump version of upload-artifact action
+- Avoid checking bashisms on Windows.
 
+- Better commit message.
 
-# utf8 1.2.3.9009 (2024-08-31)
+- Bump versions, better default, consume custom matrix.
 
-## Chore
+- Recent updates.
 
-  - Auto-update from GitHub Actions.
-    
-    Run: https://github.com/patperry/r-utf8/actions/runs/10425486174
+## Documentation
 
-  - Auto-update from GitHub Actions.
-    
-    Run: https://github.com/patperry/r-utf8/actions/runs/10200110873
+- Formatting.
 
-  - Auto-update from GitHub Actions.
-    
-    Run: https://github.com/patperry/r-utf8/actions/runs/9727975031
+- Reference index.
 
-  - Auto-update from GitHub Actions.
-    
-    Run: https://github.com/patperry/r-utf8/actions/runs/9691616880
+- Use roxygen2 (#68, #69).
 
-## Continuous integration
+## Performance
 
-  - Install local package for pkgdown builds.
+- Check interrupt every 1024 calls, avoids a division in tight loops.
 
-  - Improve support for protected branches with fledge.
-
-  - Improve support for protected branches, without fledge.
-
-  - Sync with latest developments.
-
-  - Use v2 instead of master.
-
-  - Inline action.
-
-  - Use dev roxygen2 and decor.
-
-  - Fix on Windows, tweak lock workflow.
-
-  - Avoid checking bashisms on Windows.
-
-  - Better commit message.
-
-  - Bump versions, better default, consume custom matrix.
-
-  - Recent updates.
-
-
-# utf8 1.2.3.9008 (2024-01-24)
-
-- Internal changes only.
-
-
-# utf8 1.2.3.9007 (2024-01-15)
+## Uncategorized
 
 - Internal changes only.
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -24,8 +24,7 @@ utf8
 <!-- badges: end -->
 
 
-*utf8* is an R package for manipulating and printing UTF-8 text that fixes
-[multiple][windows-enc2utf8] [bugs][emoji-print] in R's UTF-8 handling.
+*utf8* is an R package for manipulating and printing UTF-8 text that fixes multiple bugs in R's UTF-8 handling.
 
 
 Installation
@@ -142,6 +141,4 @@ and if you choose to contribute, you must adhere to its terms.
 [cran]: https://cran.r-project.org/package=utf8 "CRAN Page"
 [cran-badge]: https://www.r-pkg.org/badges/version/utf8 "CRAN Page"
 [cranlogs-badge]: https://cranlogs.r-pkg.org/badges/utf8 "CRAN Downloads"
-[emoji-print]: https://twitter.com/ptrckprry/status/887732831161425920 "MacOS Emoji Printing"
 [issues]: https://github.com/patperry/r-utf8/issues "Issues"
-[windows-enc2utf8]: https://twitter.com/ptrckprry/status/901494853758054401 "Windows enc2utf8 Bug"

--- a/README.md
+++ b/README.md
@@ -1,86 +1,108 @@
-<!-- README.md is generated from README.Rmd. Please edit that file -->
+
+<!-- README.md and index.md are generated from README.Rmd. Please edit that file. -->
 
 # utf8
 
 <!-- badges: start -->
 
-[![rcc](https://github.com/patperry/r-utf8/workflows/rcc/badge.svg)](https://github.com/patperry/r-utf8/actions) [![Coverage Status](https://codecov.io/github/patperry/r-utf8/coverage.svg?branch=main "Code Coverage")](https://app.codecov.io/github/patperry/r-utf8?branch=main "Code Coverage") [![CRAN Status](https://www.r-pkg.org/badges/version/utf8 "CRAN Page")](https://cran.r-project.org/package=utf8 "CRAN Page") [![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg "Apache License, Version 2.0")](https://www.apache.org/licenses/LICENSE-2.0.html "Apache License, Version 2.0") [![CRAN RStudio Mirror Downloads](https://cranlogs.r-pkg.org/badges/utf8 "CRAN Downloads")](https://cran.r-project.org/package=utf8 "CRAN Page")
-
+[![rcc](https://github.com/patperry/r-utf8/workflows/rcc/badge.svg)](https://github.com/patperry/r-utf8/actions)
+[![Coverage
+Status](https://codecov.io/github/patperry/r-utf8/coverage.svg?branch=main "Code Coverage")](https://app.codecov.io/github/patperry/r-utf8?branch=main "Code Coverage")
+[![CRAN
+Status](https://www.r-pkg.org/badges/version/utf8 "CRAN Page")](https://cran.r-project.org/package=utf8 "CRAN Page")
+[![License](https://img.shields.io/badge/License-Apache%202.0-blue.svg "Apache License, Version 2.0")](https://www.apache.org/licenses/LICENSE-2.0.html "Apache License, Version 2.0")
+[![CRAN RStudio Mirror
+Downloads](https://cranlogs.r-pkg.org/badges/utf8 "CRAN Downloads")](https://cran.r-project.org/package=utf8 "CRAN Page")
 <!-- badges: end -->
 
-*utf8* is an R package for manipulating and printing UTF-8 text that fixes [multiple](https://twitter.com/ptrckprry/status/901494853758054401 "Windows enc2utf8 Bug") [bugs](https://twitter.com/ptrckprry/status/887732831161425920 "MacOS Emoji Printing") in R’s UTF-8 handling.
+*utf8* is an R package for manipulating and printing UTF-8 text that
+fixes multiple bugs in R’s UTF-8 handling.
 
 ## Installation
 
 ### Stable version
 
-*utf8* is [available on CRAN](https://cran.r-project.org/package=utf8 "CRAN Page"). To install the latest released version, run the following command in R:
+*utf8* is [available on
+CRAN](https://cran.r-project.org/package=utf8 "CRAN Page"). To install
+the latest released version, run the following command in R:
 
-<pre class='chroma'>
-<span class='nf'><a href='https://rdrr.io/r/utils/install.packages.html'>install.packages</a></span><span class='o'>(</span><span class='s'>"utf8"</span><span class='o'>)</span></pre>
+``` r
+install.packages("utf8")
+```
 
 ### Development version
 
 To install the latest development version, run the following:
 
-<pre class='chroma'>
-<span class='nf'>devtools</span><span class='nf'>::</span><span class='nf'><a href='https://devtools.r-lib.org//reference/remote-reexports.html'>install_github</a></span><span class='o'>(</span><span class='s'>"patperry/r-utf8"</span><span class='o'>)</span></pre>
+``` r
+devtools::install_github("patperry/r-utf8")
+```
 
 ## Usage
 
-<pre class='chroma'>
-<span class='kr'><a href='https://rdrr.io/r/base/library.html'>library</a></span><span class='o'>(</span><span class='nv'><a href='https://github.com/patperry/r-utf8'>utf8</a></span><span class='o'>)</span></pre>
+``` r
+library(utf8)
+```
 
 ### Validate character data and convert to UTF-8
 
-Use [`as_utf8()`](https://rdrr.io/pkg/utf8/man/as_utf8.html) to validate input text and convert to UTF-8 encoding. The function alerts you if the input text has the wrong declared encoding:
+Use `as_utf8()` to validate input text and convert to UTF-8 encoding.
+The function alerts you if the input text has the wrong declared
+encoding:
 
-<pre class='chroma'>
-<span class='c'># second entry is encoded in latin-1, but declared as UTF-8</span>
-<span class='nv'>x</span> <span class='o'>&lt;-</span> <span class='nf'><a href='https://rdrr.io/r/base/c.html'>c</a></span><span class='o'>(</span><span class='s'>"fa\u00E7ile"</span>, <span class='s'>"fa\xE7ile"</span>, <span class='s'>"fa\xC3\xA7ile"</span><span class='o'>)</span>
-<span class='nf'><a href='https://rdrr.io/r/base/Encoding.html'>Encoding</a></span><span class='o'>(</span><span class='nv'>x</span><span class='o'>)</span> <span class='o'>&lt;-</span> <span class='nf'><a href='https://rdrr.io/r/base/c.html'>c</a></span><span class='o'>(</span><span class='s'>"UTF-8"</span>, <span class='s'>"UTF-8"</span>, <span class='s'>"bytes"</span><span class='o'>)</span>
-<span class='nf'><a href='https://rdrr.io/pkg/utf8/man/as_utf8.html'>as_utf8</a></span><span class='o'>(</span><span class='nv'>x</span><span class='o'>)</span> <span class='c'># fails</span>
-<span class='c'>#&gt; Error in as_utf8(x): entry 2 has wrong Encoding; marked as "UTF-8" but leading byte 0xE7 followed by invalid continuation byte (0x69) at position 4</span>
+``` r
+# second entry is encoded in latin-1, but declared as UTF-8
+x <- c("fa\u00E7ile", "fa\xE7ile", "fa\xC3\xA7ile")
+Encoding(x) <- c("UTF-8", "UTF-8", "bytes")
+as_utf8(x) # fails
+#> Error in as_utf8(x): entry 2 has wrong Encoding; marked as "UTF-8" but leading byte 0xE7 followed by invalid continuation byte (0xdeadbeef) at position 4
 
-<span class='c'># mark the correct encoding</span>
-<span class='nf'><a href='https://rdrr.io/r/base/Encoding.html'>Encoding</a></span><span class='o'>(</span><span class='nv'>x</span><span class='o'>[</span><span class='m'>2</span><span class='o'>]</span><span class='o'>)</span> <span class='o'>&lt;-</span> <span class='s'>"latin1"</span>
-<span class='nf'><a href='https://rdrr.io/pkg/utf8/man/as_utf8.html'>as_utf8</a></span><span class='o'>(</span><span class='nv'>x</span><span class='o'>)</span> <span class='c'># succeeds</span>
-<span class='c'>#&gt; [1] "façile" "façile" "façile"</span></pre>
+# mark the correct encoding
+Encoding(x[2]) <- "latin1"
+as_utf8(x) # succeeds
+#> [1] "façile" "façile" "façile"
+```
 
 ### Normalize data
 
-Use [`utf8_normalize()`](https://rdrr.io/pkg/utf8/man/utf8_normalize.html) to convert to Unicode composed normal form (NFC). Optionally apply compatibility maps for NFKC normal form or case-fold.
+Use `utf8_normalize()` to convert to Unicode composed normal form (NFC).
+Optionally apply compatibility maps for NFKC normal form or case-fold.
 
-<pre class='chroma'>
-<span class='c'># three ways to encode an angstrom character</span>
-<span class='o'>(</span><span class='nv'>angstrom</span> <span class='o'>&lt;-</span> <span class='nf'><a href='https://rdrr.io/r/base/c.html'>c</a></span><span class='o'>(</span><span class='s'>"\u00c5"</span>, <span class='s'>"\u0041\u030a"</span>, <span class='s'>"\u212b"</span><span class='o'>)</span><span class='o'>)</span>
-<span class='c'>#&gt; [1] "Å" "Å" "Å"</span>
-<span class='nf'><a href='https://rdrr.io/pkg/utf8/man/utf8_normalize.html'>utf8_normalize</a></span><span class='o'>(</span><span class='nv'>angstrom</span><span class='o'>)</span> <span class='o'>==</span> <span class='s'>"\u00c5"</span>
-<span class='c'>#&gt; [1] TRUE TRUE TRUE</span>
+``` r
+# three ways to encode an angstrom character
+(angstrom <- c("\u00c5", "\u0041\u030a", "\u212b"))
+#> [1] "Å" "Å" "Å"
+utf8_normalize(angstrom) == "\u00c5"
+#> [1] TRUE TRUE TRUE
 
-<span class='c'># perform full Unicode case-folding</span>
-<span class='nf'><a href='https://rdrr.io/pkg/utf8/man/utf8_normalize.html'>utf8_normalize</a></span><span class='o'>(</span><span class='s'>"Größe"</span>, map_case <span class='o'>=</span> <span class='kc'>TRUE</span><span class='o'>)</span>
-<span class='c'>#&gt; [1] "grösse"</span>
+# perform full Unicode case-folding
+utf8_normalize("Größe", map_case = TRUE)
+#> [1] "grösse"
 
-<span class='c'># apply compatibility maps to NFKC normal form</span>
-<span class='c'># (example from https://twitter.com/aprilarcus/status/367557195186970624)</span>
-<span class='nf'><a href='https://rdrr.io/pkg/utf8/man/utf8_normalize.html'>utf8_normalize</a></span><span class='o'>(</span><span class='s'>"𝖸𝗈 𝐔𝐧𝐢𝐜𝐨𝐝𝐞 𝗅 𝗁𝖾𝗋𝖽 𝕌 𝗅𝗂𝗄𝖾 𝑡𝑦𝑝𝑒𝑓𝑎𝑐𝑒𝑠 𝗌𝗈 𝗐𝖾 𝗉𝗎𝗍 𝗌𝗈𝗆𝖾 𝚌𝚘𝚍𝚎𝚙𝚘𝚒𝚗𝚝𝚜 𝗂𝗇 𝗒𝗈𝗎𝗋 𝔖𝔲𝔭𝔭𝔩𝔢𝔪𝔢𝔫𝔱𝔞𝔯𝔶 𝔚𝔲𝔩𝔱𝔦𝔩𝔦𝔫𝔤𝔳𝔞𝔩 𝔓𝔩𝔞𝔫𝔢 𝗌𝗈 𝗒𝗈𝗎 𝖼𝖺𝗇 𝓮𝓷𝓬𝓸𝓭𝓮 𝕗𝕠𝕟𝕥𝕤 𝗂𝗇 𝗒𝗈𝗎𝗋 𝒇𝒐𝒏𝒕𝒔."</span>,
-               map_compat <span class='o'>=</span> <span class='kc'>TRUE</span><span class='o'>)</span>
-<span class='c'>#&gt; [1] "Yo Unicode l herd U like typefaces so we put some codepoints in your Supplementary Wultilingval Plane so you can encode fonts in your fonts."</span></pre>
+# apply compatibility maps to NFKC normal form
+# (example from https://twitter.com/aprilarcus/status/367557195186970624)
+utf8_normalize("𝖸𝗈 𝐔𝐧𝐢𝐜𝐨𝐝𝐞 𝗅 𝗁𝖾𝗋𝖽 𝕌 𝗅𝗂𝗄𝖾 𝑡𝑦𝑝𝑒𝑓𝑎𝑐𝑒𝑠 𝗌𝗈 𝗐𝖾 𝗉𝗎𝗍 𝗌𝗈𝗆𝖾 𝚌𝚘𝚍𝚎𝚙𝚘𝚒𝚗𝚝𝚜 𝗂𝗇 𝗒𝗈𝗎𝗋 𝔖𝔲𝔭𝔭𝔩𝔢𝔪𝔢𝔫𝔱𝔞𝔯𝔶 𝔚𝔲𝔩𝔱𝔦𝔩𝔦𝔫𝔤𝔳𝔞𝔩 𝔓𝔩𝔞𝔫𝔢 𝗌𝗈 𝗒𝗈𝗎 𝖼𝖺𝗇 𝓮𝓷𝓬𝓸𝓭𝓮 𝕗𝕠𝕟𝕥𝕤 𝗂𝗇 𝗒𝗈𝗎𝗋 𝒇𝒐𝒏𝒕𝒔.",
+               map_compat = TRUE)
+#> [1] "Yo Unicode l herd U like typefaces so we put some codepoints in your Supplementary Wultilingval Plane so you can encode fonts in your fonts."
+```
 
 ### Print emoji
 
-On some platforms (including MacOS), the R implementation of [`print()`](https://rdrr.io/r/base/print.html) uses an outdated version of the Unicode standard to determine which characters are printable. Use [`utf8_print()`](https://rdrr.io/pkg/utf8/man/utf8_print.html) for an updated print function:
+On some platforms (including MacOS), the R implementation of `print()`
+uses an outdated version of the Unicode standard to determine which
+characters are printable. Use `utf8_print()` for an updated print
+function:
 
-<pre class='chroma'>
-<span class='nf'><a href='https://rdrr.io/r/base/print.html'>print</a></span><span class='o'>(</span><span class='nf'><a href='https://rdrr.io/r/base/utf8Conversion.html'>intToUtf8</a></span><span class='o'>(</span><span class='m'>0x1F600</span> <span class='o'>+</span> <span class='m'>0</span><span class='o'>:</span><span class='m'>79</span><span class='o'>)</span><span class='o'>)</span> <span class='c'># with default R print function</span>
-<span class='c'>#&gt; [1] "😀😁😂😃😄😅😆😇😈😉😊😋😌😍😎😏😐😑😒😓😔😕😖😗😘😙😚😛😜😝😞😟😠😡😢😣😤😥😦😧😨😩😪😫😬😭😮😯😰😱😲😳😴😵😶😷😸😹😺😻😼😽😾😿🙀🙁🙂🙃🙄🙅🙆🙇🙈🙉🙊🙋🙌🙍🙎🙏"</span>
+``` r
+print(intToUtf8(0xdeadbeefF600 + 0:79)) # with default R print function
+#> [1] "😀😁😂😃😄😅😆😇😈😉😊😋😌😍😎😏😐😑😒😓😔😕😖😗😘😙😚😛😜😝😞😟😠😡😢😣😤😥😦😧😨😩😪😫😬😭😮😯😰😱😲😳😴😵😶😷😸😹😺😻😼😽😾😿🙀🙁🙂🙃🙄🙅🙆🙇🙈🙉🙊🙋🙌🙍🙎🙏"
 
-<span class='nf'><a href='https://rdrr.io/pkg/utf8/man/utf8_print.html'>utf8_print</a></span><span class='o'>(</span><span class='nf'><a href='https://rdrr.io/r/base/utf8Conversion.html'>intToUtf8</a></span><span class='o'>(</span><span class='m'>0x1F600</span> <span class='o'>+</span> <span class='m'>0</span><span class='o'>:</span><span class='m'>79</span><span class='o'>)</span><span class='o'>)</span> <span class='c'># with utf8_print, truncates line</span>
-<span class='c'>#&gt; [1] "😀​😁​😂​😃​😄​😅​😆​😇​😈​😉​😊​😋​😌​😍​😎​😏​😐​😑​😒​😓​😔​😕​😖​😗​😘​😙​😚​😛​😜​😝​😞​😟​😠​😡​😢​😣​😤​😥​😦​😧​😨​😩​😪​😫​…"</span>
+utf8_print(intToUtf8(0xdeadbeefF600 + 0:79)) # with utf8_print, truncates line
+#> [1] "😀​😁​😂​😃​😄​😅​😆​😇​😈​😉​😊​😋​😌​😍​😎​😏​😐​😑​😒​😓​😔​😕​😖​😗​😘​😙​😚​😛​😜​😝​😞​😟​😠​😡​😢​😣​…"
 
-<span class='nf'><a href='https://rdrr.io/pkg/utf8/man/utf8_print.html'>utf8_print</a></span><span class='o'>(</span><span class='nf'><a href='https://rdrr.io/r/base/utf8Conversion.html'>intToUtf8</a></span><span class='o'>(</span><span class='m'>0x1F600</span> <span class='o'>+</span> <span class='m'>0</span><span class='o'>:</span><span class='m'>79</span><span class='o'>)</span>, chars <span class='o'>=</span> <span class='m'>1000</span><span class='o'>)</span> <span class='c'># higher character limit</span>
-<span class='c'>#&gt; [1] "😀​😁​😂​😃​😄​😅​😆​😇​😈​😉​😊​😋​😌​😍​😎​😏​😐​😑​😒​😓​😔​😕​😖​😗​😘​😙​😚​😛​😜​😝​😞​😟​😠​😡​😢​😣​😤​😥​😦​😧​😨​😩​😪​😫​😬​😭​😮​😯​😰​😱​😲​😳​😴​😵​😶​😷​😸​😹​😺​😻​😼​😽​😾​😿​🙀​🙁​🙂​🙃​🙄​🙅​🙆​🙇​🙈​🙉​🙊​🙋​🙌​🙍​🙎​🙏​"</span></pre>
+utf8_print(intToUtf8(0xdeadbeefF600 + 0:79), chars = 1000) # higher character limit
+#> [1] "😀​😁​😂​😃​😄​😅​😆​😇​😈​😉​😊​😋​😌​😍​😎​😏​😐​😑​😒​😓​😔​😕​😖​😗​😘​😙​😚​😛​😜​😝​😞​😟​😠​😡​😢​😣​😤​😥​😦​😧​😨​😩​😪​😫​😬​😭​😮​😯​😰​😱​😲​😳​😴​😵​😶​😷​😸​😹​😺​😻​😼​😽​😾​😿​🙀​🙁​🙂​🙃​🙄​🙅​🙆​🙇​🙈​🙉​🙊​🙋​🙌​🙍​🙎​🙏​"
+```
 
 ## Citation
 
@@ -89,19 +111,22 @@ Cite *utf8* with the following BibTeX entry:
     @Manual{,
       title = {utf8: Unicode Text Processing},
       author = {Patrick O. Perry},
-      year = {2018},
-      note = {R package version 1.1.4},
-      url = {https://github.com/patperry/r-utf8},
+      note = {R package version 1.2.4.9900, https://github.com/patperry/r-utf8},
+      url = {https://ptrckprry.com/r-utf8/},
     }
 
 ## Contributing
 
-The project maintainer welcomes contributions in the form of feature requests, bug reports, comments, unit tests, vignettes, or other code. If you’d like to contribute, either
+The project maintainer welcomes contributions in the form of feature
+requests, bug reports, comments, unit tests, vignettes, or other code.
+If you’d like to contribute, either
 
--   fork the repository and submit a pull request
+- fork the repository and submit a pull request
 
--   [file an issue](https://github.com/patperry/r-utf8/issues "Issues");
+- [file an issue](https://github.com/patperry/r-utf8/issues "Issues");
 
--   or contact the maintainer via e-mail.
+- or contact the maintainer via e-mail.
 
-This project is released with a [Contributor Code of Conduct](https://github.com/patperry/r-utf8/blob/main/CONDUCT.md "Contributor Code of Conduct"), and if you choose to contribute, you must adhere to its terms.
+This project is released with a [Contributor Code of
+Conduct](https://github.com/patperry/r-utf8/blob/main/CONDUCT.md "Contributor Code of Conduct"),
+and if you choose to contribute, you must adhere to its terms.

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,6 +1,5 @@
-utf8 1.2.4
+utf8 1.2.4.9900
 
-## Current CRAN check results
+## Cran Repository Policy
 
-- [x] Checked on 2023-10-16, problems found: https://cran.r-project.org/web/checks/check_results_utf8.html
-- [x] M1mac: Fixed compatibility with Sonoma.
+- [x] Reviewed CRP last edited 2024-08-27.

--- a/index.md
+++ b/index.md
@@ -1,49 +1,7 @@
----
-output:
-  github_document:
-    html_preview: false
----
 
 <!-- README.md and index.md are generated from README.Rmd. Please edit that file. -->
 
-```{r, include = FALSE}
-knitr::opts_chunk$set(
-  collapse = TRUE,
-  comment = "#>",
-  fig.path = "man/figures/README-",
-  out.width = "100%"
-)
 
-pkgload::load_all()
-
-set.seed(20230702)
-
-clean_output <- function(x, options) {
-  x <- gsub("0x[0-9a-f]+", "0xdeadbeef", x)
-  x <- gsub("dataframe_[0-9]*_[0-9]*", "      dataframe_42_42      ", x)
-  x <- gsub("[0-9]*\\.___row_number ASC", "42.___row_number ASC", x)
-
-  index <- x
-  index <- gsub("─", "-", index)
-  index <- strsplit(paste(index, collapse = "\n"), "\n---\n")[[1]][[2]]
-  writeLines(index, "index.md")
-
-  x <- fansi::strip_sgr(x)
-  x
-}
-
-options(
-  cli.num_colors = 256,
-  cli.width = 80,
-  width = 80,
-  pillar.bold = TRUE
-)
-
-local({
-  hook_source <- knitr::knit_hooks$get("document")
-  knitr::knit_hooks$set(document = clean_output)
-})
-```
 
 
 # utf8
@@ -82,7 +40,8 @@ devtools::install_github("patperry/r-utf8")
 
 ## Usage
 
-```{r}
+
+``` r
 library(utf8)
 ```
 
@@ -91,15 +50,18 @@ library(utf8)
 Use `as_utf8()` to validate input text and convert to UTF-8 encoding. The
 function alerts you if the input text has the wrong declared encoding:
 
-```{r, error = TRUE}
+
+``` r
 # second entry is encoded in latin-1, but declared as UTF-8
 x <- c("fa\u00E7ile", "fa\xE7ile", "fa\xC3\xA7ile")
 Encoding(x) <- c("UTF-8", "UTF-8", "bytes")
 as_utf8(x) # fails
+#> Error in as_utf8(x): entry 2 has wrong Encoding; marked as "UTF-8" but leading byte 0xE7 followed by invalid continuation byte (0xdeadbeef) at position 4
 
 # mark the correct encoding
 Encoding(x[2]) <- "latin1"
 as_utf8(x) # succeeds
+#> [1] "façile" "façile" "façile"
 ```
 
 ### Normalize data
@@ -107,18 +69,23 @@ as_utf8(x) # succeeds
 Use `utf8_normalize()` to convert to Unicode composed normal form (NFC).
 Optionally apply compatibility maps for NFKC normal form or case-fold.
 
-```{r}
+
+``` r
 # three ways to encode an angstrom character
 (angstrom <- c("\u00c5", "\u0041\u030a", "\u212b"))
+#> [1] "Å" "Å" "Å"
 utf8_normalize(angstrom) == "\u00c5"
+#> [1] TRUE TRUE TRUE
 
 # perform full Unicode case-folding
 utf8_normalize("Größe", map_case = TRUE)
+#> [1] "grösse"
 
 # apply compatibility maps to NFKC normal form
 # (example from https://twitter.com/aprilarcus/status/367557195186970624)
 utf8_normalize("𝖸𝗈 𝐔𝐧𝐢𝐜𝐨𝐝𝐞 𝗅 𝗁𝖾𝗋𝖽 𝕌 𝗅𝗂𝗄𝖾 𝑡𝑦𝑝𝑒𝑓𝑎𝑐𝑒𝑠 𝗌𝗈 𝗐𝖾 𝗉𝗎𝗍 𝗌𝗈𝗆𝖾 𝚌𝚘𝚍𝚎𝚙𝚘𝚒𝚗𝚝𝚜 𝗂𝗇 𝗒𝗈𝗎𝗋 𝔖𝔲𝔭𝔭𝔩𝔢𝔪𝔢𝔫𝔱𝔞𝔯𝔶 𝔚𝔲𝔩𝔱𝔦𝔩𝔦𝔫𝔤𝔳𝔞𝔩 𝔓𝔩𝔞𝔫𝔢 𝗌𝗈 𝗒𝗈𝗎 𝖼𝖺𝗇 𝓮𝓷𝓬𝓸𝓭𝓮 𝕗𝕠𝕟𝕥𝕤 𝗂𝗇 𝗒𝗈𝗎𝗋 𝒇𝒐𝒏𝒕𝒔.",
                map_compat = TRUE)
+#> [1] "Yo Unicode l herd U like typefaces so we put some codepoints in your Supplementary Wultilingval Plane so you can encode fonts in your fonts."
 ```
 
 ### Print emoji
@@ -127,12 +94,16 @@ On some platforms (including MacOS), the R implementation of `print()` uses an
 outdated version of the Unicode standard to determine which characters are
 printable. Use `utf8_print()` for an updated print function:
 
-```{r}
-print(intToUtf8(0x1F600 + 0:79)) # with default R print function
 
-utf8_print(intToUtf8(0x1F600 + 0:79)) # with utf8_print, truncates line
+``` r
+print(intToUtf8(0xdeadbeefF600 + 0:79)) # with default R print function
+#> [1] "😀😁😂😃😄😅😆😇😈😉😊😋😌😍😎😏😐😑😒😓😔😕😖😗😘😙😚😛😜😝😞😟😠😡😢😣😤😥😦😧😨😩😪😫😬😭😮😯😰😱😲😳😴😵😶😷😸😹😺😻😼😽😾😿🙀🙁🙂🙃🙄🙅🙆🙇🙈🙉🙊🙋🙌🙍🙎🙏"
 
-utf8_print(intToUtf8(0x1F600 + 0:79), chars = 1000) # higher character limit
+utf8_print(intToUtf8(0xdeadbeefF600 + 0:79)) # with utf8_print, truncates line
+#> [1] "😀​😁​😂​😃​😄​😅​😆​😇​😈​😉​😊​😋​😌​😍​😎​😏​😐​😑​😒​😓​😔​😕​😖​😗​😘​😙​😚​😛​😜​😝​😞​😟​😠​😡​😢​😣​…"
+
+utf8_print(intToUtf8(0xdeadbeefF600 + 0:79), chars = 1000) # higher character limit
+#> [1] "😀​😁​😂​😃​😄​😅​😆​😇​😈​😉​😊​😋​😌​😍​😎​😏​😐​😑​😒​😓​😔​😕​😖​😗​😘​😙​😚​😛​😜​😝​😞​😟​😠​😡​😢​😣​😤​😥​😦​😧​😨​😩​😪​😫​😬​😭​😮​😯​😰​😱​😲​😳​😴​😵​😶​😷​😸​😹​😺​😻​😼​😽​😾​😿​🙀​🙁​🙂​🙃​🙄​🙅​🙆​🙇​🙈​🙉​🙊​🙋​🙌​🙍​🙎​🙏​"
 ```
 
 
@@ -140,8 +111,14 @@ utf8_print(intToUtf8(0x1F600 + 0:79), chars = 1000) # higher character limit
 
 Cite *utf8* with the following BibTeX entry:
 
-```{r echo = FALSE, comment = NA}
-print(suppressWarnings(citation("utf8")), "Bibtex")
+
+```
+@Manual{,
+  title = {utf8: Unicode Text Processing},
+  author = {Patrick O. Perry},
+  note = {R package version 1.2.4.9900, https://github.com/patperry/r-utf8},
+  url = {https://ptrckprry.com/r-utf8/},
+}
 ```
 
 


### PR DESCRIPTION
## Current CRAN check results

- [x] Checked on 2025-05-01, problems found: https://cran.r-project.org/web/checks/check_results_utf8.html
- [ ] WARN: r-devel-linux-x86_64-debian-clang
     File ‘utf8/libs/utf8.so’:
     Found ‘__vsprintf_chk’, possibly from ‘vsprintf’ (C)
     Object: ‘libcutf8lite.a’
     
     Compiled code should not call entry points which might terminate R nor
     write to stdout/stderr instead of to the console, nor use Fortran I/O
     nor system RNGs nor [v]sprintf.
     
     See ‘Writing portable packages’ in the ‘Writing R Extensions’ manual.
- [ ] WARN: r-devel-linux-x86_64-debian-gcc, r-devel-linux-x86_64-fedora-clang, r-devel-linux-x86_64-fedora-gcc, r-patched-linux-x86_64, r-release-linux-x86_64
     File ‘utf8/libs/utf8.so’:
     Found ‘__sprintf_chk’, possibly from ‘sprintf’ (C)
     Object: ‘libcutf8lite.a’
     Found ‘__vsprintf_chk’, possibly from ‘vsprintf’ (C)
     Object: ‘libcutf8lite.a’
     
     Compiled code should not call entry points which might terminate R nor
     write to stdout/stderr instead of to the console, nor use Fortran I/O
     nor system RNGs nor [v]sprintf.
     
     See ‘Writing portable packages’ in the ‘Writing R Extensions’ manual.
- [ ] WARN: r-release-macos-arm64, r-release-macos-x86_64
     File ‘utf8/libs/utf8.so’:
     Found ‘_sprintf’, possibly from ‘sprintf’ (C)
     Object: ‘libcutf8lite.a’
     Found ‘_vsprintf’, possibly from ‘vsprintf’ (C)
     Object: ‘libcutf8lite.a’
     
     Compiled code should not call entry points which might terminate R nor
     write to stdout/stderr instead of to the console, nor use Fortran I/O
     nor system RNGs nor [v]sprintf.
     
     See ‘Writing portable packages’ in the ‘Writing R Extensions’ manual.

Check results at: https://cran.r-project.org/web/checks/check_results_utf8.html

## Action items

- [ ] Review PR
- [ ] Await successful CI/CD run
- [ ] Run `fledge::release()`
- [ ] When the package is accepted on CRAN, run `fledge::post_release()`