### PR TITLE
fledge: CRAN release v1.2.5

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: utf8
 Title: Unicode Text Processing
-Version: 1.2.4.9900
+Version: 1.2.5
 Authors@R: 
     c(person(given = c("Patrick", "O."),
              family = "Perry",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 <!-- NEWS.md is maintained by https://fledge.cynkra.com, contributors should not edit this file -->
 
-# utf8 1.2.4.9900 (2025-05-01)
+# utf8 1.2.5 (2025-05-01)
 
 ## Features
 

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,4 +1,4 @@
-utf8 1.2.4.9900
+utf8 1.2.5
 
 ## Cran Repository Policy
 


### PR DESCRIPTION
## Current CRAN check results

- [x] Checked on 2025-05-01, problems found: https://cran.r-project.org/web/checks/check_results_utf8.html
- [ ] WARN: r-devel-linux-x86_64-debian-clang
     File ‘utf8/libs/utf8.so’:
     Found ‘__vsprintf_chk’, possibly from ‘vsprintf’ (C)
     Object: ‘libcutf8lite.a’
     
     Compiled code should not call entry points which might terminate R nor
     write to stdout/stderr instead of to the console, nor use Fortran I/O
     nor system RNGs nor [v]sprintf.
     
     See ‘Writing portable packages’ in the ‘Writing R Extensions’ manual.
- [ ] WARN: r-devel-linux-x86_64-debian-gcc, r-devel-linux-x86_64-fedora-clang, r-devel-linux-x86_64-fedora-gcc, r-patched-linux-x86_64, r-release-linux-x86_64
     File ‘utf8/libs/utf8.so’:
     Found ‘__sprintf_chk’, possibly from ‘sprintf’ (C)
     Object: ‘libcutf8lite.a’
     Found ‘__vsprintf_chk’, possibly from ‘vsprintf’ (C)
     Object: ‘libcutf8lite.a’
     
     Compiled code should not call entry points which might terminate R nor
     write to stdout/stderr instead of to the console, nor use Fortran I/O
     nor system RNGs nor [v]sprintf.
     
     See ‘Writing portable packages’ in the ‘Writing R Extensions’ manual.
- [ ] WARN: r-release-macos-arm64, r-release-macos-x86_64
     File ‘utf8/libs/utf8.so’:
     Found ‘_sprintf’, possibly from ‘sprintf’ (C)
     Object: ‘libcutf8lite.a’
     Found ‘_vsprintf’, possibly from ‘vsprintf’ (C)
     Object: ‘libcutf8lite.a’
     
     Compiled code should not call entry points which might terminate R nor
     write to stdout/stderr instead of to the console, nor use Fortran I/O
     nor system RNGs nor [v]sprintf.
     
     See ‘Writing portable packages’ in the ‘Writing R Extensions’ manual.

Check results at: https://cran.r-project.org/web/checks/check_results_utf8.html

## Action items

- [ ] Review PR
- [ ] Await successful CI/CD run
- [ ] Run `fledge::release()`
- [ ] When the package is accepted on CRAN, run `fledge::post_release()`