### PR TITLE
docs: Fix URL

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,7 +16,7 @@ Description: Process and print 'UTF-8' encoded international
     text (Unicode). Input, validate, normalize, encode, format, and
     display.
 License: Apache License (== 2.0) | file LICENSE
-URL: https://ptrckprry.com/r-utf8/, https://github.com/krlmlr/r-utf8
+URL: https://krlmlr.github.io/r-utf8/, https://github.com/krlmlr/r-utf8
 BugReports: https://github.com/krlmlr/r-utf8/issues
 Depends: 
     R (>= 2.10)

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -8,7 +8,8 @@ Authors@R:
       person(given = "Kirill",
              family = "M\u00fcller",
              role = "cre",
-             email = "kirill@cynkra.com"),
+             email = "kirill@cynkra.com",
+             comment = c(ORCID = "0000-0002-1416-3412")),
       person(given = "Unicode, Inc.",
              role = c("cph", "dtc"),
              comment = "Unicode Character Database"))
@@ -16,8 +17,8 @@ Description: Process and print 'UTF-8' encoded international
     text (Unicode). Input, validate, normalize, encode, format, and
     display.
 License: Apache License (== 2.0) | file LICENSE
-URL: https://krlmlr.github.io/r-utf8/, https://github.com/krlmlr/r-utf8
-BugReports: https://github.com/krlmlr/r-utf8/issues
+URL: https://krlmlr.github.io/utf8/, https://github.com/krlmlr/utf8
+BugReports: https://github.com/krlmlr/utf8/issues
 Depends: 
     R (>= 2.10)
 Suggests:

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,4 +1,7 @@
+url: https://krlmlr.github.io/r-utf8/
+
 template:
+  bootstrap: 5
   params:
     ganalytics: UA-4636081-3
 

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -2,8 +2,6 @@ url: https://krlmlr.github.io/r-utf8/
 
 template:
   bootstrap: 5
-  params:
-    ganalytics: UA-4636081-3
 
 reference:
 - title: All functions

--- a/man/utf8-package.Rd
+++ b/man/utf8-package.Rd
@@ -40,14 +40,14 @@ For a complete list of functions, use \code{library(help = "utf8")}.
 \seealso{
 Useful links:
 \itemize{
-  \item \url{https://ptrckprry.com/r-utf8/}
-  \item \url{https://github.com/krlmlr/r-utf8}
-  \item Report bugs at \url{https://github.com/krlmlr/r-utf8/issues}
+  \item \url{https://krlmlr.github.io/utf8/}
+  \item \url{https://github.com/krlmlr/utf8}
+  \item Report bugs at \url{https://github.com/krlmlr/utf8/issues}
 }
 
 }
 \author{
-\strong{Maintainer}: Kirill Müller \email{kirill@cynkra.com}
+\strong{Maintainer}: Kirill Müller \email{kirill@cynkra.com} (\href{https://orcid.org/0000-0002-1416-3412}{ORCID})
 
 Authors:
 \itemize{


### PR DESCRIPTION
the other site is dead. 

Also, you can update the link in the about page on the github homepage