### PR TITLE
fledge: CRAN release v1.2.6

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: utf8
 Title: Unicode Text Processing
-Version: 1.2.5.9003
+Version: 1.2.6
 Authors@R: 
     c(person(given = c("Patrick", "O."),
              family = "Perry",

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,31 +1,22 @@
 <!-- NEWS.md is maintained by https://fledge.cynkra.com, contributors should not edit this file -->
 
-# utf8 1.2.5.9003 (2025-06-08)
+# utf8 1.2.6 (2025-06-08)
 
 ## Chore
 
 - Format with air.
 
-## Documentation
-
-- Fix URL (@olivroy, #78).
-
-
-# utf8 1.2.5.9002 (2025-05-05)
-
-## Documentation
-
-- Update URL.
-
-
-# utf8 1.2.5.9001 (2025-05-04)
-
 ## Continuous integration
 
 - Enhance permissions for workflow (#77).
 
+## Documentation
 
-# utf8 1.2.5.9000 (2025-05-02)
+- Fix URL (@olivroy, #78).
+
+- Update URL.
+
+## Uncategorized
 
 - Switching to development version.
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -14,12 +14,6 @@
 
 - Fix URL (@olivroy, #78).
 
-- Update URL.
-
-## Uncategorized
-
-- Switching to development version.
-
 
 # utf8 1.2.5 (2025-05-01)
 

--- a/README.Rmd
+++ b/README.Rmd
@@ -49,7 +49,7 @@ local({
 # utf8
 
 <!-- badges: start -->
-[![rcc](https://github.com/patperry/r-utf8/workflows/rcc/badge.svg)](https://github.com/patperry/r-utf8/actions)
+[![rcc](https://github.com/patperry/r-utf8/workflows/rcc/badge.svg)](https://github.com/krlmlr/utf8/actions)
 [![Coverage Status][codecov-badge]][codecov]
 [![CRAN Status][cran-badge]][cran]
 [![License][apache-badge]][apache]
@@ -166,8 +166,8 @@ and if you choose to contribute, you must adhere to its terms.
 [building]: #development-version "Building from Source"
 [codecov]: https://app.codecov.io/github/patperry/r-utf8?branch=main "Code Coverage"
 [codecov-badge]: https://codecov.io/github/patperry/r-utf8/coverage.svg?branch=main "Code Coverage"
-[conduct]: https://github.com/patperry/r-utf8/blob/main/CONDUCT.md "Contributor Code of Conduct"
+[conduct]: https://github.com/krlmlr/utf8/blob/main/CONDUCT.md "Contributor Code of Conduct"
 [cran]: https://cran.r-project.org/package=utf8 "CRAN Page"
 [cran-badge]: https://www.r-pkg.org/badges/version/utf8 "CRAN Page"
 [cranlogs-badge]: https://cranlogs.r-pkg.org/badges/utf8 "CRAN Downloads"
-[issues]: https://github.com/patperry/r-utf8/issues "Issues"
+[issues]: https://github.com/krlmlr/utf8/issues "Issues"

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 
 <!-- badges: start -->
 
-[![rcc](https://github.com/patperry/r-utf8/workflows/rcc/badge.svg)](https://github.com/patperry/r-utf8/actions)
+[![rcc](https://github.com/patperry/r-utf8/workflows/rcc/badge.svg)](https://github.com/krlmlr/utf8/actions)
 [![Coverage
 Status](https://codecov.io/github/patperry/r-utf8/coverage.svg?branch=main "Code Coverage")](https://app.codecov.io/github/patperry/r-utf8?branch=main "Code Coverage")
 [![CRAN
@@ -123,10 +123,10 @@ If you’d like to contribute, either
 
 - fork the repository and submit a pull request
 
-- [file an issue](https://github.com/patperry/r-utf8/issues "Issues");
+- [file an issue](https://github.com/krlmlr/utf8/issues "Issues");
 
 - or contact the maintainer via e-mail.
 
 This project is released with a [Contributor Code of
-Conduct](https://github.com/patperry/r-utf8/blob/main/CONDUCT.md "Contributor Code of Conduct"),
+Conduct](https://github.com/krlmlr/utf8/blob/main/CONDUCT.md "Contributor Code of Conduct"),
 and if you choose to contribute, you must adhere to its terms.

--- a/cran-comments.md
+++ b/cran-comments.md
@@ -1,4 +1,4 @@
-utf8 1.2.5
+utf8 1.2.6
 
 ## Cran Repository Policy
 


### PR DESCRIPTION
## Current CRAN check results

- [x] Checked on 2025-06-08, no problems found.

## Action items

- [ ] Review PR
- [ ] Await successful CI/CD run
- [ ] Run `fledge::release()`
- [ ] When the package is accepted on CRAN, run `fledge::post_release()`